### PR TITLE
Split Gameplay Console Into Dedicated Page And Simplify Landing

### DIFF
--- a/web/components/CodeEditor.tsx
+++ b/web/components/CodeEditor.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import dynamic from 'next/dynamic'
-import { SWIMMER_MODULE_TEMPLATE, DEFAULT_VALUES, SwimmingStyle, STYLE_NAMES } from '@/src/contracts/moveTemplates'
+import { SWIMMER_MODULE_TEMPLATE, DEFAULT_VALUES } from '@/src/contracts/moveTemplates'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 
@@ -10,24 +10,23 @@ const Editor = dynamic(() => import('@monaco-editor/react'), {
 })
 
 interface CodeEditorProps {
-  onDeploy: (name: string, style: number) => void
+  onMint: (name: string, species: string) => void
   disabled?: boolean
 }
 
-export function CodeEditor({ onDeploy, disabled }: CodeEditorProps) {
-  const [name, setName] = useState('MySwimmer')
-  const [speed, setSpeed] = useState(DEFAULT_VALUES.speed)
-  const [stamina, setStamina] = useState(DEFAULT_VALUES.stamina)
-  const [style, setStyle] = useState(DEFAULT_VALUES.style)
+export function CodeEditor({ onMint, disabled }: CodeEditorProps) {
+  const [name, setName] = useState('My Swimmer')
+  const [species, setSpecies] = useState('Pacific Orca')
+  const [baseSpeed, setBaseSpeed] = useState(DEFAULT_VALUES.baseSpeedPerHour)
+  const [tunaBonus, setTunaBonus] = useState(DEFAULT_VALUES.tunaBonus)
   const [isDeploying, setIsDeploying] = useState(false)
 
   // 템플릿에 값 적용
   const getProcessedCode = useCallback(() => {
     return SWIMMER_MODULE_TEMPLATE
-      .replace('{{SPEED}}', speed.toString())
-      .replace('{{STAMINA}}', stamina.toString())
-      .replace('{{STYLE}}', style.toString())
-  }, [speed, stamina, style])
+      .replace(/{{BASE_SPEED_PER_HOUR}}/g, baseSpeed.toString())
+      .replace(/{{TUNA_BONUS}}/g, tunaBonus.toString())
+  }, [baseSpeed, tunaBonus])
 
   const handleDeploy = async () => {
     if (!name.trim()) {
@@ -35,9 +34,14 @@ export function CodeEditor({ onDeploy, disabled }: CodeEditorProps) {
       return
     }
 
+    if (!species.trim()) {
+      alert('수영 선수가 어떤 종인지 정해주세요!')
+      return
+    }
+
     setIsDeploying(true)
     try {
-      await onDeploy(name, style)
+      await onMint(name.trim(), species.trim())
     } catch (error) {
       console.error('Deploy failed:', error)
       alert('배포 실패: ' + (error as Error).message)
@@ -49,7 +53,7 @@ export function CodeEditor({ onDeploy, disabled }: CodeEditorProps) {
   return (
     <Card className="flex flex-col h-full">
       <CardHeader>
-        <CardTitle>2단계. 선수 파라미터 설정</CardTitle>
+        <CardTitle>2단계. 첫 Swimmer 민팅</CardTitle>
       </CardHeader>
       <CardContent>
         <div className="space-y-3">
@@ -65,51 +69,53 @@ export function CodeEditor({ onDeploy, disabled }: CodeEditorProps) {
               placeholder="수영 선수 이름 입력"
             />
           </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              종(species)
+            </label>
+            <input
+              type="text"
+              value={species}
+              onChange={(e) => setSpecies(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="예: Pacific Orca"
+            />
+          </div>
           
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                속도 (10-100)
+                기본 속도 (m / h)
               </label>
               <input
                 type="number"
                 min="10"
-                max="100"
-                value={speed}
-                onChange={(e) => setSpeed(Number(e.target.value))}
+                max="1000"
+                value={baseSpeed}
+                onChange={(e) => setBaseSpeed(Number(e.target.value))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
+              <p className="text-xs text-gray-500 mt-1">
+                코드 예시에서 자동 전진 속도를 조정합니다.
+              </p>
             </div>
-            
+
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                체력 (50-100)
+                참치 보너스 (m)
               </label>
               <input
                 type="number"
-                min="50"
-                max="100"
-                value={stamina}
-                onChange={(e) => setStamina(Number(e.target.value))}
+                min="1"
+                max="500"
+                value={tunaBonus}
+                onChange={(e) => setTunaBonus(Number(e.target.value))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
-            </div>
-            
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                스타일
-              </label>
-              <select
-                value={style}
-                onChange={(e) => setStyle(Number(e.target.value))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                {Object.entries(STYLE_NAMES).map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
+              <p className="text-xs text-gray-500 mt-1">
+                참치를 먹였을 때 추가 이동할 거리를 설정합니다.
+              </p>
             </div>
           </div>
         </div>
@@ -139,7 +145,7 @@ export function CodeEditor({ onDeploy, disabled }: CodeEditorProps) {
           size="lg"
           className="w-full"
         >
-          {isDeploying ? '처리 중...' : '🚀 NFT 민팅하기'}
+          {isDeploying ? '처리 중...' : '🚀 Swimmer 민팅하기'}
         </Button>
       </CardFooter>
     </Card>

--- a/web/lib/types/swimmer.ts
+++ b/web/lib/types/swimmer.ts
@@ -1,0 +1,13 @@
+export interface SwimmerSummary {
+  id: string
+  name: string
+  species: string
+  distanceTraveled: number
+  baseSpeedPerHour: number
+  lastUpdateTimestampMs: number
+}
+
+export interface TunaCanItem {
+  id: string
+  energy: number
+}

--- a/web/pages/gameplay.tsx
+++ b/web/pages/gameplay.tsx
@@ -1,0 +1,447 @@
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+import { useCurrentAccount, useSignAndExecuteTransaction } from '@mysten/dapp-kit'
+import { Transaction } from '@mysten/sui/transactions'
+import { WalletConnect } from '@/components/WalletConnect'
+import { SwimmingPool } from '@/components/SwimmingPool'
+import { DeployContract } from '@/components/DeployContract'
+import { CodeEditor } from '@/components/CodeEditor'
+import { Button } from '@/components/ui/button'
+import { SuiService, CLOCK_OBJECT_ID } from '@/lib/services/suiService'
+import { SwimmerSummary, TunaCanItem } from '@/lib/types/swimmer'
+
+export default function Gameplay() {
+  const currentAccount = useCurrentAccount()
+  const { mutate: signAndExecute } = useSignAndExecuteTransaction()
+  const [suiService] = useState(() => new SuiService('testnet'))
+
+  const [swimmers, setSwimmers] = useState<SwimmerSummary[]>([])
+  const [tunaCans, setTunaCans] = useState<TunaCanItem[]>([])
+  const [packageId, setPackageId] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [selectedSwimmerId, setSelectedSwimmerId] = useState('')
+  const [selectedTunaId, setSelectedTunaId] = useState('')
+
+  const fetchSwimmers = useCallback(async () => {
+    if (!currentAccount?.address) return
+
+    try {
+      const userSwimmers = await suiService.getUserSwimmers(currentAccount.address)
+      const formattedSwimmers: SwimmerSummary[] = userSwimmers.map((obj: any) => ({
+        id: obj.data?.objectId || '',
+        name: obj.data?.content?.fields?.name || 'Unknown Swimmer',
+        species: obj.data?.content?.fields?.species || 'Mystery Species',
+        distanceTraveled: Number(obj.data?.content?.fields?.distance_traveled || 0),
+        baseSpeedPerHour: Number(obj.data?.content?.fields?.base_speed_per_hour || 0),
+        lastUpdateTimestampMs: Number(obj.data?.content?.fields?.last_update_timestamp_ms || Date.now()),
+      }))
+      setSwimmers(formattedSwimmers)
+    } catch (error) {
+      console.error('Failed to fetch swimmers:', error)
+    }
+  }, [currentAccount, suiService])
+
+  const fetchTunaCans = useCallback(async () => {
+    if (!currentAccount?.address) return
+
+    try {
+      const userTuna = await suiService.getUserTunaCans(currentAccount.address)
+      const formattedTuna: TunaCanItem[] = userTuna.map((obj: any) => ({
+        id: obj.data?.objectId || '',
+        energy: Number(obj.data?.content?.fields?.energy || 0),
+      }))
+      setTunaCans(formattedTuna)
+    } catch (error) {
+      console.error('Failed to fetch tuna cans:', error)
+    }
+  }, [currentAccount, suiService])
+
+  useEffect(() => {
+    const loadAssets = () => {
+      fetchSwimmers()
+      fetchTunaCans()
+    }
+
+    loadAssets()
+    const interval = setInterval(loadAssets, 6000)
+    return () => clearInterval(interval)
+  }, [fetchSwimmers, fetchTunaCans])
+
+  useEffect(() => {
+    if (swimmers.length === 0) {
+      setSelectedSwimmerId('')
+      return
+    }
+
+    if (!selectedSwimmerId || !swimmers.some(swimmer => swimmer.id === selectedSwimmerId)) {
+      setSelectedSwimmerId(swimmers[0].id)
+    }
+  }, [swimmers, selectedSwimmerId])
+
+  useEffect(() => {
+    if (tunaCans.length === 0) {
+      setSelectedTunaId('')
+      return
+    }
+
+    if (!selectedTunaId || !tunaCans.some(tuna => tuna.id === selectedTunaId)) {
+      setSelectedTunaId(tunaCans[0].id)
+    }
+  }, [tunaCans, selectedTunaId])
+
+  const handleMintSwimmer = async (name: string, species: string) => {
+    if (!currentAccount) {
+      alert('먼저 지갑을 연결해주세요!')
+      return
+    }
+
+    if (!packageId) {
+      alert('먼저 스마트 컨트랙트를 배포해주세요!')
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const tx = new Transaction()
+      tx.moveCall({
+        target: `${packageId}::swimmer::mint_swimmer`,
+        arguments: [
+          tx.pure.string(name),
+          tx.pure.string(species),
+          tx.object(CLOCK_OBJECT_ID),
+        ],
+      })
+
+      signAndExecute(
+        {
+          transaction: tx,
+        },
+        {
+          onSuccess: () => {
+            alert('🎉 새로운 Swimmer NFT가 도착했어요!')
+            fetchSwimmers()
+          },
+          onError: (error) => {
+            console.error('Transaction failed:', error)
+            alert('트랜잭션 실패: ' + error.message)
+          },
+        }
+      )
+    } catch (error) {
+      console.error('Failed to create swimmer:', error)
+      alert('수영 선수 생성 실패!')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleUpdateProgress = async () => {
+    if (!currentAccount) {
+      alert('먼저 지갑을 연결해주세요!')
+      return
+    }
+
+    if (!packageId) {
+      alert('먼저 스마트 컨트랙트를 배포해주세요!')
+      return
+    }
+
+    if (!selectedSwimmerId) {
+      alert('업데이트할 Swimmer를 선택해주세요!')
+      return
+    }
+
+    setActionLoading('update')
+    try {
+      const tx = new Transaction()
+      tx.moveCall({
+        target: `${packageId}::swimmer::update_progress`,
+        arguments: [
+          tx.object(selectedSwimmerId),
+          tx.object(CLOCK_OBJECT_ID),
+        ],
+      })
+
+      signAndExecute(
+        {
+          transaction: tx,
+        },
+        {
+          onSuccess: () => {
+            alert('⏱ Swimmer가 자동으로 앞으로 나아갔어요!')
+            fetchSwimmers()
+            setActionLoading(null)
+          },
+          onError: (error) => {
+            console.error('Update progress failed:', error)
+            alert('업데이트 실패: ' + error.message)
+            setActionLoading(null)
+          },
+        }
+      )
+    } catch (error) {
+      console.error('Failed to update progress:', error)
+      alert('업데이트 실패: ' + (error as Error).message)
+      setActionLoading(null)
+    }
+  }
+
+  const handleMintTuna = async () => {
+    if (!currentAccount) {
+      alert('먼저 지갑을 연결해주세요!')
+      return
+    }
+
+    if (!packageId) {
+      alert('먼저 스마트 컨트랙트를 배포해주세요!')
+      return
+    }
+
+    setActionLoading('mintTuna')
+    try {
+      const tx = new Transaction()
+      tx.moveCall({
+        target: `${packageId}::swimmer::mint_tuna`,
+        arguments: [],
+      })
+
+      signAndExecute(
+        {
+          transaction: tx,
+        },
+        {
+          onSuccess: () => {
+            alert('🍣 참치 통조림이 인벤토리에 추가되었어요!')
+            fetchTunaCans()
+            setActionLoading(null)
+          },
+          onError: (error) => {
+            console.error('Mint tuna failed:', error)
+            alert('참치 민팅 실패: ' + error.message)
+            setActionLoading(null)
+          },
+        }
+      )
+    } catch (error) {
+      console.error('Failed to mint tuna:', error)
+      alert('참치 민팅 실패: ' + (error as Error).message)
+      setActionLoading(null)
+    }
+  }
+
+  const handleEatTuna = async () => {
+    if (!currentAccount) {
+      alert('먼저 지갑을 연결해주세요!')
+      return
+    }
+
+    if (!packageId) {
+      alert('먼저 스마트 컨트랙트를 배포해주세요!')
+      return
+    }
+
+    if (!selectedSwimmerId) {
+      alert('먹이를 줄 Swimmer를 선택해주세요!')
+      return
+    }
+
+    if (!selectedTunaId) {
+      alert('먼저 참치 통조림을 준비해주세요!')
+      return
+    }
+
+    setActionLoading('eatTuna')
+    try {
+      const tx = new Transaction()
+      tx.moveCall({
+        target: `${packageId}::swimmer::eat_tuna`,
+        arguments: [
+          tx.object(selectedSwimmerId),
+          tx.object(selectedTunaId),
+          tx.object(CLOCK_OBJECT_ID),
+        ],
+      })
+
+      signAndExecute(
+        {
+          transaction: tx,
+        },
+        {
+          onSuccess: () => {
+            alert('💪 참치 보너스로 거리가 증가했어요!')
+            fetchSwimmers()
+            fetchTunaCans()
+            setActionLoading(null)
+          },
+          onError: (error) => {
+            console.error('Eat tuna failed:', error)
+            alert('먹이 주기 실패: ' + error.message)
+            setActionLoading(null)
+          },
+        }
+      )
+    } catch (error) {
+      console.error('Failed to eat tuna:', error)
+      alert('먹이 주기 실패: ' + (error as Error).message)
+      setActionLoading(null)
+    }
+  }
+
+  const selectedSwimmer = swimmers.find(swimmer => swimmer.id === selectedSwimmerId)
+  const selectedTuna = tunaCans.find(tuna => tuna.id === selectedTunaId)
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200">
+        <div className="container mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-purple-600">🎮 Gameplay Console</p>
+            <h1 className="text-3xl font-bold text-gray-900">Swimmer와 상호작용하기</h1>
+            <p className="text-sm text-gray-600 mt-1">자동 전진, 아이템 사용, PTB 실습을 이 화면에서 진행하세요.</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button asChild variant="outline" size="sm">
+              <Link href="/">← 메인으로</Link>
+            </Button>
+            <WalletConnect />
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-12 space-y-12">
+        <section className="grid gap-6 md:grid-cols-3">
+          <div className="rounded-xl border border-blue-100 bg-blue-50 px-5 py-4">
+            <p className="text-xs uppercase text-blue-600 font-semibold">연결된 지갑</p>
+            <p className="mt-2 text-sm font-mono text-gray-800">
+              {currentAccount?.address
+                ? `${currentAccount.address.slice(0, 6)}...${currentAccount.address.slice(-4)}`
+                : '지갑 미연결'}
+            </p>
+          </div>
+          <div className="rounded-xl border border-emerald-100 bg-emerald-50 px-5 py-4">
+            <p className="text-xs uppercase text-emerald-600 font-semibold">보유한 Swimmer</p>
+            <p className="mt-2 text-2xl font-bold text-emerald-700">{swimmers.length}</p>
+          </div>
+          <div className="rounded-xl border border-purple-100 bg-purple-50 px-5 py-4">
+            <p className="text-xs uppercase text-purple-600 font-semibold">패키지 상태</p>
+            <p className="mt-2 text-sm text-gray-800">{packageId ? '✅ 준비 완료' : '배포 필요'}</p>
+            {packageId && (
+              <p className="mt-1 text-xs font-mono text-gray-500 break-all">{packageId}</p>
+            )}
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 lg:grid-cols-[1.1fr_1fr] gap-6">
+          <DeployContract onPackageDeployed={setPackageId} />
+          <CodeEditor onMint={handleMintSwimmer} disabled={!packageId || !currentAccount || isLoading} />
+        </section>
+
+        <section className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-gray-900">🏊 수영장</h2>
+            <span className="text-xs text-gray-500">Swimmer 위치는 자동 전진에 따라 갱신됩니다.</span>
+          </div>
+          <SwimmingPool swimmers={swimmers} />
+        </section>
+
+        <section className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between mb-6">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">🎮 Gameplay Console</h2>
+              <p className="text-sm text-gray-600">Programmable Transaction Block으로 Swimmer와 TunaCan을 동시에 다뤄보세요.</p>
+            </div>
+            <div className="text-xs text-gray-500">인벤토리 {tunaCans.length}개</div>
+          </div>
+
+          <div className="space-y-6">
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 uppercase mb-1">Swimmer 선택</label>
+              <select
+                value={selectedSwimmerId}
+                onChange={(event) => setSelectedSwimmerId(event.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                disabled={swimmers.length === 0}
+              >
+                {swimmers.length === 0 ? (
+                  <option>먼저 Swimmer를 민팅하세요</option>
+                ) : (
+                  swimmers.map((swimmer) => (
+                    <option key={swimmer.id} value={swimmer.id}>
+                      {swimmer.name} · {swimmer.distanceTraveled}m
+                    </option>
+                  ))
+                )}
+              </select>
+              {selectedSwimmer && (
+                <p className="mt-1 text-xs text-gray-500">
+                  기본 속도 {selectedSwimmer.baseSpeedPerHour}m/h · 마지막 업데이트 {new Date(selectedSwimmer.lastUpdateTimestampMs).toLocaleString()}
+                </p>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                onClick={handleUpdateProgress}
+                disabled={!packageId || !currentAccount || !selectedSwimmerId || actionLoading === 'update'}
+                size="sm"
+              >
+                {actionLoading === 'update' ? '업데이트 중...' : '⏱ 자동 전진'}
+              </Button>
+              <Button
+                onClick={handleMintTuna}
+                disabled={!packageId || !currentAccount || actionLoading === 'mintTuna'}
+                variant="secondary"
+                size="sm"
+              >
+                {actionLoading === 'mintTuna' ? '민팅 중...' : '🍣 참치 민팅'}
+              </Button>
+            </div>
+
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 uppercase mb-1">TunaCan 인벤토리</label>
+              <select
+                value={selectedTunaId}
+                onChange={(event) => setSelectedTunaId(event.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                disabled={tunaCans.length === 0}
+              >
+                {tunaCans.length === 0 ? (
+                  <option>참치를 민팅하면 여기에 표시됩니다</option>
+                ) : (
+                  tunaCans.map((tuna) => (
+                    <option key={tuna.id} value={tuna.id}>
+                      {tuna.id.slice(0, 6)}...{tuna.id.slice(-4)} · +{tuna.energy}m
+                    </option>
+                  ))
+                )}
+              </select>
+              {selectedTuna && (
+                <p className="mt-1 text-xs text-gray-500">보너스 거리 +{selectedTuna.energy}m</p>
+              )}
+            </div>
+
+            <Button
+              onClick={handleEatTuna}
+              disabled={!packageId || !currentAccount || !selectedSwimmerId || !selectedTunaId || actionLoading === 'eatTuna'}
+              size="sm"
+              className="w-full md:w-auto"
+            >
+              {actionLoading === 'eatTuna' ? '처리 중...' : '🍽 Swimmer에게 먹이기'}
+            </Button>
+
+            <div className="rounded-lg bg-gray-50 border border-gray-200 p-4 text-sm text-gray-600">
+              <p>✅ 순서 팁: <span className="font-semibold text-gray-800">update_progress → mint_tuna → eat_tuna</span> 흐름으로 PTB를 구성하면 안전하게 자동 전진과 아이템 소비를 결합할 수 있습니다.</p>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer className="bg-white border-t border-gray-200 mt-12">
+        <div className="container mx-auto px-4 py-6 text-center text-sm text-gray-600">
+          Made with 🌊 for Sui-mmers · Keep experimenting!
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,58 +1,138 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
 import { useCurrentAccount, useSignAndExecuteTransaction } from '@mysten/dapp-kit'
 import { WalletConnect } from '@/components/WalletConnect'
 import { CodeEditor } from '@/components/CodeEditor'
-import { SwimmingPool } from '@/components/SwimmingPool'
 import { Lesson } from '@/components/Lesson'
 import { DeployContract } from '@/components/DeployContract'
-import { SuiService } from '@/lib/services/suiService'
+import { SuiService, CLOCK_OBJECT_ID } from '@/lib/services/suiService'
 import { Transaction } from '@mysten/sui/transactions'
 import { Button } from '@/components/ui/button'
+import { SwimmerSummary } from '@/lib/types/swimmer'
 
-interface Swimmer {
-  id: string
-  name: string
-  speed: number
-  style: number
-  stamina: number
-  medals: number
-}
+const SESSION_DATA = [
+  {
+    id: 'session-1',
+    title: 'Session 1 · Sui와 Move의 첫 만남',
+    summary: 'NFT를 설계하고 자동으로 전진하는 Swimmer를 민팅해요.',
+    lessons: [
+      {
+        lessonNumber: 1,
+        title: 'Lesson 1 · 나만의 수영선수 struct',
+        description: 'UID와 핵심 상태를 담은 Swimmer 객체 설계도를 작성합니다.',
+        objectives: [
+          'Sui 객체는 UID 필드를 필수로 가진다는 사실 이해',
+          'distance_traveled와 last_update_timestamp_ms로 진행 상황 저장',
+          'Move 모듈과 struct 선언 패턴 익히기',
+        ],
+        tips: [
+          'has key 능력이 있어야 온체인에 저장됩니다.',
+          '필드 이름은 스네이크 케이스로 작성하세요.',
+        ],
+      },
+      {
+        lessonNumber: 2,
+        title: 'Lesson 2 · mint_swimmer 함수',
+        description: 'public entry fun으로 누구나 새로운 Swimmer NFT를 받을 수 있게 합니다.',
+        objectives: [
+          'TxContext에서 object::new로 UID 생성하기',
+          'transfer::public_transfer로 민팅한 NFT 전달',
+          'Clock 객체를 이용해 초기 업데이트 타임스탬프 설정',
+        ],
+        tips: [
+          'Clock shared object ID는 0x6입니다.',
+          'string::utf8으로 vector<u8>를 안전하게 변환하세요.',
+        ],
+      },
+      {
+        lessonNumber: 3,
+        title: 'Lesson 3 · 게으른 업데이트 패턴',
+        description: '자동 전진을 계산해주는 update_progress 함수를 구현합니다.',
+        objectives: [
+          'clock::timestamp_ms로 현재 블록 시간 읽기',
+          '경과 시간과 기본 속도로 distance_traveled 증가',
+          '이벤트를 emit해 온체인에서 진행 상황 로깅',
+        ],
+        tips: [
+          '현재 시간이 last_update보다 클 때만 계산하세요.',
+          'division 전에 overflow가 나지 않도록 u64 범위를 확인하세요.',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'session-2',
+    title: 'Session 2 · PTB와 객체 상호작용',
+    summary: '아이템 객체를 만들고 Programmable Transaction Blocks로 함께 다룹니다.',
+    lessons: [
+      {
+        lessonNumber: 4,
+        title: 'Lesson 4 · TunaCan struct & mint_tuna',
+        description: '기력 회복 아이템을 별도의 객체로 발행해봅니다.',
+        objectives: [
+          '아이템도 Swimmer처럼 has key 능력이 필요함 이해',
+          'mint_tuna 함수에서 object::new와 transfer 사용',
+          'energy 필드로 보너스 거리를 보관',
+        ],
+        tips: [
+          '아이템은 소모되면 object::delete로 제거합니다.',
+          '필요하다면 energy 값을 조정해 게임 밸런스를 맞춰보세요.',
+        ],
+      },
+      {
+        lessonNumber: 5,
+        title: 'Lesson 5 · eat_tuna PTB 구성',
+        description: 'Swimmer와 TunaCan을 한 트랜잭션에서 처리해 밸런스를 유지합니다.',
+        objectives: [
+          'Programmable Transaction Block으로 두 객체를 동시에 전달',
+          'update_progress를 먼저 호출해 자동 전진 적용',
+          'object::delete로 소비된 TunaCan 정리',
+        ],
+        tips: [
+          '트랜잭션 중 하나라도 실패하면 전체가 롤백됩니다.',
+          'Sui Explorer에서 이벤트 로그를 확인해보세요.',
+        ],
+      },
+    ],
+  },
+]
 
 export default function Home() {
   const currentAccount = useCurrentAccount()
   const { mutate: signAndExecute } = useSignAndExecuteTransaction()
-  const [swimmers, setSwimmers] = useState<Swimmer[]>([])
+  const [swimmers, setSwimmers] = useState<SwimmerSummary[]>([])
   const [suiService] = useState(() => new SuiService('testnet'))
   const [isLoading, setIsLoading] = useState(false)
   const [packageId, setPackageId] = useState<string | null>(null)
+  const [isCourseOpen, setIsCourseOpen] = useState(false)
+
+  const fetchSwimmers = useCallback(async () => {
+    if (!currentAccount?.address) return
+
+    try {
+      const userSwimmers = await suiService.getUserSwimmers(currentAccount.address)
+      const formattedSwimmers: SwimmerSummary[] = userSwimmers.map((obj: any) => ({
+        id: obj.data?.objectId || '',
+        name: obj.data?.content?.fields?.name || 'Unknown Swimmer',
+        species: obj.data?.content?.fields?.species || 'Mystery Species',
+        distanceTraveled: Number(obj.data?.content?.fields?.distance_traveled || 0),
+        baseSpeedPerHour: Number(obj.data?.content?.fields?.base_speed_per_hour || 0),
+        lastUpdateTimestampMs: Number(obj.data?.content?.fields?.last_update_timestamp_ms || Date.now()),
+      }))
+      setSwimmers(formattedSwimmers)
+    } catch (error) {
+      console.error('Failed to fetch swimmers:', error)
+    }
+  }, [currentAccount, suiService])
 
   // 사용자의 수영 선수 NFT 조회
   useEffect(() => {
-    const fetchSwimmers = async () => {
-      if (currentAccount?.address) {
-        try {
-          const userSwimmers = await suiService.getUserSwimmers(currentAccount.address)
-          const formattedSwimmers: Swimmer[] = userSwimmers.map((obj: any) => ({
-            id: obj.data?.objectId || '',
-            name: obj.data?.content?.fields?.name || 'Unknown',
-            speed: Number(obj.data?.content?.fields?.speed || 30),
-            style: Number(obj.data?.content?.fields?.style || 0),
-            stamina: Number(obj.data?.content?.fields?.stamina || 60),
-            medals: Number(obj.data?.content?.fields?.medals || 0),
-          }))
-          setSwimmers(formattedSwimmers)
-        } catch (error) {
-          console.error('Failed to fetch swimmers:', error)
-        }
-      }
-    }
-
     fetchSwimmers()
-    const interval = setInterval(fetchSwimmers, 5000)
+    const interval = setInterval(fetchSwimmers, 6000)
     return () => clearInterval(interval)
-  }, [currentAccount, suiService])
+  }, [fetchSwimmers])
 
-  const handleDeploy = async (name: string, style: number) => {
+  const handleMintSwimmer = async (name: string, species: string) => {
     if (!currentAccount) {
       alert('먼저 지갑을 연결해주세요!')
       return
@@ -68,10 +148,11 @@ export default function Home() {
       const tx = new Transaction()
       
       tx.moveCall({
-        target: `${packageId}::swimmer::create_swimmer`,
+        target: `${packageId}::swimmer::mint_swimmer`,
         arguments: [
           tx.pure.string(name),
-          tx.pure.u8(style),
+          tx.pure.string(species),
+          tx.object(CLOCK_OBJECT_ID),
         ],
       })
 
@@ -82,17 +163,8 @@ export default function Home() {
         {
           onSuccess: (result) => {
             console.log('Transaction successful:', result)
-            alert('🎉 수영 선수가 성공적으로 생성되었습니다!')
-            
-            const newSwimmer: Swimmer = {
-              id: Date.now().toString(),
-              name,
-              speed: 30,
-              style,
-              stamina: 60,
-              medals: 0,
-            }
-            setSwimmers([...swimmers, newSwimmer])
+            alert('🎉 새로운 Swimmer NFT가 도착했어요!')
+            fetchSwimmers()
           },
           onError: (error) => {
             console.error('Transaction failed:', error)
@@ -110,111 +182,131 @@ export default function Home() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Header */}
       <header className="bg-white border-b border-gray-200">
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex justify-between items-center">
-            <div className="flex items-center gap-4">
-              <span className="text-3xl">🏊</span>
-              <div>
-                <h1 className="text-xl font-bold text-gray-900">Sui Swimming</h1>
-                <p className="text-sm text-gray-600">Learn Move by Gaming</p>
-              </div>
-            </div>
+        <div className="container mx-auto px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-blue-600">🌊 Sui-mmers</p>
+            <h1 className="text-3xl font-bold text-gray-900">Move & Sui를 게임처럼 배우기</h1>
+            <p className="text-sm text-gray-600 mt-1">
+              Swimmer NFT를 설계하고, 자동 전진과 아이템 시스템을 통해 Move의 핵심 개념을 익혀보세요.
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button variant="outline" onClick={() => setIsCourseOpen(true)}>
+              📘 코스 열람
+            </Button>
             <WalletConnect />
           </div>
         </div>
       </header>
 
-      {/* Main Content */}
-      <main className="container mx-auto px-4 py-8">
-        {/* 레슨 섹션 */}
-        <div className="mb-8">
-          <div className="bg-white rounded-lg p-6 border border-gray-200">
-            <Lesson 
-              lessonNumber={1}
-              title="Move로 수영 선수 NFT 만들기"
-              description="Move 언어의 기초를 배우며 나만의 수영 선수 NFT를 만들어보세요."
-              objectives={[
-                "Move 모듈 구조와 기본 문법 이해",
-                "NFT 구조체(struct) 정의하기", 
-                "파라미터로 속성 커스터마이징",
-                "Sui 테스트넷에 실제 배포하기"
-              ]}
-              tips={[
-                "속도와 체력 값을 조정해보세요",
-                "수영 스타일을 선택하면 애니메이션이 달라집니다",
-                "배포 후에는 수영장에서 선수를 확인할 수 있어요"
-              ]}
-            />
+      <main className="container mx-auto px-4 py-12 space-y-12">
+        <section className="grid gap-6 md:grid-cols-[2fr_1fr]">
+          <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+            <h2 className="text-xl font-semibold text-gray-900">시작하기</h2>
+            <p className="mt-3 text-sm text-gray-600">
+              ① 패키지를 배포하고 ② Swimmer를 한 명 민팅한 뒤 ③ Gameplay Console에서 PTB를 연습하세요.
+            </p>
+            <div className="mt-6 grid gap-4 sm:grid-cols-3">
+              <div className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3">
+                <p className="text-xs uppercase text-blue-600 font-semibold">연결된 지갑</p>
+                <p className="mt-1 text-sm font-mono text-gray-800">
+                  {currentAccount?.address
+                    ? `${currentAccount.address.slice(0, 6)}...${currentAccount.address.slice(-4)}`
+                    : '지갑 미연결'}
+                </p>
+              </div>
+              <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-3">
+                <p className="text-xs uppercase text-emerald-600 font-semibold">보유한 Swimmer</p>
+                <p className="mt-1 text-2xl font-bold text-emerald-700">{swimmers.length}</p>
+              </div>
+              <div className="rounded-lg border border-purple-100 bg-purple-50 px-4 py-3">
+                <p className="text-xs uppercase text-purple-600 font-semibold">패키지 상태</p>
+                <p className="mt-1 text-sm text-gray-800">
+                  {packageId ? '✅ 준비 완료' : '배포 필요'}
+                </p>
+              </div>
+            </div>
+            <div className="mt-6">
+              <Button asChild size="sm" variant="secondary">
+                <Link href="/gameplay">🎮 Gameplay Console로 이동</Link>
+              </Button>
+            </div>
           </div>
-        </div>
 
-        {/* 메인 작업 영역 */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-          {/* 왼쪽: 1단계(패키지 배포) + 2단계(NFT 민팅) */}
-          <div className="space-y-6">
-            {/* 1단계 */}
-            <DeployContract onPackageDeployed={setPackageId} />
-            
-            {/* 2단계 */}
-            <CodeEditor onDeploy={handleDeploy} disabled={!packageId || !currentAccount} />
+          <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+            <h3 className="text-lg font-semibold text-gray-900">빠른 링크</h3>
+            <ul className="mt-3 space-y-2 text-sm text-gray-600">
+              <li>• <a href="https://docs.sui.io/learn" className="text-blue-600 hover:text-blue-800" target="_blank" rel="noopener noreferrer">Sui 학습하기</a></li>
+              <li>• <a href="https://move-language.github.io" className="text-blue-600 hover:text-blue-800" target="_blank" rel="noopener noreferrer">Move 언어 문서</a></li>
+              <li>• <a href="https://faucet.testnet.sui.io" className="text-blue-600 hover:text-blue-800" target="_blank" rel="noopener noreferrer">Testnet Faucet</a></li>
+            </ul>
           </div>
-          
-          {/* 오른쪽: 수영장 시각화 */}
-          <div>
-            <h2 className="text-lg font-bold text-gray-900 mb-4">🏊 수영장</h2>
-            <SwimmingPool swimmers={swimmers} />
-          </div>
-        </div>
-        
-        {/* 추가 정보 섹션 */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-md">
-            <h3 className="font-bold text-gray-900 mb-2">📚 Move 언어란?</h3>
-            <p className="text-sm text-gray-600">
-              Move는 디지털 자산을 안전하게 관리하기 위해 설계된 프로그래밍 언어입니다.
-            </p>
-          </div>
-          
-          <div className="bg-white p-6 rounded-lg border border-gray-200">
-            <h3 className="font-bold text-gray-900 mb-2">🔗 Testnet Faucet</h3>
-            <p className="text-sm text-gray-600 mb-3">
-              테스트 SUI 토큰이 필요하신가요?
-            </p>
-            <Button asChild variant="secondary" size="sm">
-              <a
-                href="https://faucet.testnet.sui.io"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Faucet에서 받기 →
-              </a>
+        </section>
+
+        <section className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">🏊 Gameplay Console 미리보기</h2>
+          <p className="text-sm text-gray-600">
+            수영장 상황, 자동 전진, 참치 아이템 등 핵심 상호작용은 Gameplay Console에서 진행됩니다. 버튼을 눌러 전체 콘솔 화면으로 이동해보세요.
+          </p>
+          <div className="mt-4">
+            <Button asChild size="sm" variant="outline">
+              <Link href="/gameplay">콘솔 열기 →</Link>
             </Button>
           </div>
-          
-          <div className="bg-white p-6 rounded-lg border border-gray-200">
-            <h3 className="font-bold text-gray-900 mb-2">🎯 다음 레슨</h3>
-            <p className="text-sm text-gray-600">
-              레슨 2: train 함수로 선수 능력치 향상시키기
-            </p>
-          </div>
-        </div>
+        </section>
+
+        <section className="grid grid-cols-1 lg:grid-cols-[1.1fr_1fr] gap-6">
+          <DeployContract onPackageDeployed={setPackageId} />
+          <CodeEditor onMint={handleMintSwimmer} disabled={!packageId || !currentAccount || isLoading} />
+        </section>
+
+        <section className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">왜 Move인가요?</h2>
+          <p className="text-sm text-gray-600">
+            Move는 자산 안전성과 동시 실행을 고려한 스마트 컨트랙트 언어입니다. Swimmer 프로젝트를 따라가며 객체 모델, 공유 객체, Programmable Transaction Block 등을 자연스럽게 경험할 수 있습니다.
+          </p>
+        </section>
       </main>
 
-      {/* Footer */}
-      <footer className="bg-white border-t border-gray-200 mt-16">
+      <footer className="bg-white border-t border-gray-200 mt-12">
         <div className="container mx-auto px-4 py-6">
           <div className="text-center">
-            <p className="text-sm text-gray-600">Made with ❤️ for Sui Blockchain Education</p>
-            <div className="mt-2 flex justify-center gap-4">
-              <a href="https://docs.sui.io" className="text-sm text-blue-600 hover:text-blue-800" target="_blank">Sui Docs</a>
-              <span className="text-gray-400">•</span>
-              <a href="https://move-language.github.io" className="text-sm text-blue-600 hover:text-blue-800" target="_blank">Move Language</a>
-            </div>
+            <p className="text-sm text-gray-600">Made with 🌊 for Sui-mmers · Keep swimming forward!</p>
           </div>
         </div>
       </footer>
+
+      {isCourseOpen && (
+        <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 backdrop-blur-sm py-16 px-4">
+          <div className="max-w-5xl w-full bg-white rounded-2xl shadow-xl overflow-hidden">
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 bg-gray-50">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-blue-600 font-semibold">Sui-mmers 코스 지도</p>
+                <h3 className="text-xl font-bold text-gray-900">Session별 학습 여정</h3>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => setIsCourseOpen(false)}>
+                닫기
+              </Button>
+            </div>
+            <div className="p-6 space-y-8 max-h-[70vh] overflow-y-auto">
+              {SESSION_DATA.map((session) => (
+                <div key={session.id} className="space-y-4">
+                  <div>
+                    <p className="text-sm text-blue-600 font-semibold">{session.title}</p>
+                    <p className="text-sm text-gray-600">{session.summary}</p>
+                  </div>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    {session.lessons.map((lesson) => (
+                      <Lesson key={lesson.lessonNumber} {...lesson} />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/contracts/moveTemplates.ts
+++ b/web/src/contracts/moveTemplates.ts
@@ -1,52 +1,143 @@
 // Move 컨트랙트 템플릿과 바이트코드
 export const SWIMMER_MODULE_TEMPLATE = `module swimming::swimmer {
-  struct Swimmer has key {
-    id: UID,
-    name: String,
-    speed: u64,
-    style: u8,
-    stamina: u64,
-    medals: u64
-  }
-  
-  public fun create_swimmer(
-    name: String,
-    ctx: &mut TxContext
-  ) {
-    let swimmer = Swimmer {
-      id: object::new(ctx),
-      name: name,
-      speed: {{SPEED}},     // 수정 가능
-      style: {{STYLE}},     // 수정 가능
-      stamina: {{STAMINA}}, // 수정 가능
-      medals: 0
-    };
-    
-    transfer::public_transfer(
-      swimmer, 
-      tx_context::sender(ctx)
-    );
-  }
+    use sui::clock::{Self, Clock};
+    use sui::event;
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer;
+    use std::string::{Self, String};
+
+    /// 수영선수의 기본 이동 속도 (1시간 기준, 미터 단위)
+    const BASE_DISTANCE_PER_HOUR: u64 = {{BASE_SPEED_PER_HOUR}};
+
+    /// 참치 통조림을 먹었을 때 추가 이동 거리 (미터 단위)
+    const TUNA_DISTANCE_BONUS: u64 = {{TUNA_BONUS}};
+
+    /// 수영선수 NFT 구조체입니다.
+    public struct Swimmer has key, store {
+        id: UID,
+        owner: address,
+        name: String,
+        species: String,
+        distance_traveled: u64,
+        base_speed_per_hour: u64,
+        last_update_timestamp_ms: u64,
+    }
+
+    /// 참치 통조림 아이템입니다.
+    public struct TunaCan has key, store {
+        id: UID,
+        energy: u64,
+    }
+
+    /// 신규 수영선수가 탄생했을 때 발생하는 이벤트입니다.
+    public struct SwimmerMinted has copy, drop {
+        swimmer_id: address,
+        owner: address,
+        name: String,
+        species: String,
+    }
+
+    /// 자동 전진이 적용되었을 때 발생하는 이벤트입니다.
+    public struct ProgressUpdated has copy, drop {
+        swimmer_id: address,
+        new_distance: u64,
+    }
+
+    /// 참치를 먹었을 때 발생하는 이벤트입니다.
+    public struct TunaEaten has copy, drop {
+        swimmer_id: address,
+        total_distance: u64,
+        bonus_applied: u64,
+    }
+
+    /// 새로운 수영선수 NFT를 민팅합니다.
+    public entry fun mint_swimmer(
+        name: vector<u8>,
+        species: vector<u8>,
+        clock: &Clock,
+        ctx: &mut TxContext
+    ) {
+        let owner = tx_context::sender(ctx);
+        let swimmer = Swimmer {
+            id: object::new(ctx),
+            owner,
+            name: string::utf8(name),
+            species: string::utf8(species),
+            distance_traveled: 0,
+            base_speed_per_hour: BASE_DISTANCE_PER_HOUR,
+            last_update_timestamp_ms: clock::timestamp_ms(clock),
+        };
+
+        event::emit(SwimmerMinted {
+            swimmer_id: object::uid_to_address(&swimmer.id),
+            owner,
+            name: string::clone(&swimmer.name),
+            species: string::clone(&swimmer.species),
+        });
+
+        transfer::public_transfer(swimmer, owner);
+    }
+
+    /// 마지막으로 업데이트된 이후 경과한 시간만큼 자동으로 전진시킵니다.
+    public entry fun update_progress(
+        swimmer: &mut Swimmer,
+        clock: &Clock
+    ) {
+        let current_time = clock::timestamp_ms(clock);
+        let last_time = swimmer.last_update_timestamp_ms;
+
+        if (current_time > last_time) {
+            let elapsed_time_ms = current_time - last_time;
+            let distance_to_add = (elapsed_time_ms * swimmer.base_speed_per_hour) / 3_600_000;
+
+            if (distance_to_add > 0) {
+                swimmer.distance_traveled = swimmer.distance_traveled + distance_to_add;
+                swimmer.last_update_timestamp_ms = current_time;
+
+                event::emit(ProgressUpdated {
+                    swimmer_id: object::uid_to_address(&swimmer.id),
+                    new_distance: swimmer.distance_traveled,
+                });
+            }
+        }
+    }
+
+    /// 참치 통조림 NFT를 민팅합니다.
+    public entry fun mint_tuna(
+        ctx: &mut TxContext
+    ) {
+        let tuna = TunaCan {
+            id: object::new(ctx),
+            energy: TUNA_DISTANCE_BONUS,
+        };
+
+        transfer::public_transfer(tuna, tx_context::sender(ctx));
+    }
+
+    /// 참치를 먹여 추가 거리를 얻고, 사용한 참치 NFT는 소멸시킵니다.
+    public entry fun eat_tuna(
+        swimmer: &mut Swimmer,
+        tuna: TunaCan,
+        clock: &Clock
+    ) {
+        update_progress(swimmer, clock);
+
+        let TunaCan { id, energy } = tuna;
+        swimmer.distance_traveled = swimmer.distance_traveled + energy;
+        object::delete(id);
+
+        event::emit(TunaEaten {
+            swimmer_id: object::uid_to_address(&swimmer.id),
+            total_distance: swimmer.distance_traveled,
+            bonus_applied: energy,
+        });
+    }
 }`;
 
 // 수영 스타일 enum
-export enum SwimmingStyle {
-  FREESTYLE = 0,
-  BACKSTROKE = 1,
-  BREASTSTROKE = 2,
-  BUTTERFLY = 3,
-}
-
-export const STYLE_NAMES = {
-  [SwimmingStyle.FREESTYLE]: "자유형",
-  [SwimmingStyle.BACKSTROKE]: "배영",
-  [SwimmingStyle.BREASTSTROKE]: "평영",
-  [SwimmingStyle.BUTTERFLY]: "접영",
-};
-
 // 기본값
 export const DEFAULT_VALUES = {
-  speed: 30,
-  stamina: 60,
-  style: SwimmingStyle.FREESTYLE,
+  baseSpeedPerHour: 100,
+  tunaBonus: 10,
 };


### PR DESCRIPTION

Summary
- Replaced the crowded landing layout with a calm hero, quick-start guide, and deploy/mint flow, moving the session roadmap into a modal opened via “📘 코스 열람” 
- Introduced /gameplay as the focused Gameplay Console for minting swimmers, updating progress, minting/feeding tuna, and viewing the live pool, with shared data types moved to lib/types/swimmer.ts 
- Updated shared services and components so both pages reuse the same Swimmer/Tuna structures 